### PR TITLE
Corrects a syntax error in addModuleStyles call

### DIFF
--- a/EmbedVideo.hooks.php
+++ b/EmbedVideo.hooks.php
@@ -140,7 +140,7 @@ class EmbedVideoHooks {
 
 		$html = self::generateWrapperHTML($html);
 
-		$wgOut->addModuleStyles(['ext.embedVideo']);
+		$wgOut->addModuleStyles( 'ext.embedVideo' );
 
 		return array(
 			$html,


### PR DESCRIPTION
Corrects the error:

Parse error: syntax error, unexpected '[', expecting ')' in /var/www/mediawiki-1.20.3/extensions/EmbedVideo/EmbedVideo.hooks.php on line 143

(php 5.3.3)
