### PR TITLE
add media.ccc.de embed support

### DIFF
--- a/classes/VideoService.php
+++ b/classes/VideoService.php
@@ -361,6 +361,18 @@ class VideoService {
 			'id_regex'		=> [
 				'#^(?:id_)?([\d\w-]+)$#is'
 			]
+		],
+		'mediacccde' => [
+			'embed'     => '<iframe src="https://media.ccc.de/v/%1$s/oembed" width="%2$d" height="%3$d" frameborder="0" allowfullscreen="true" scrolling="no"></iframe>',
+			'default_width' => 660,
+			'default_ratio' => 1.77777777777778, //(16 / 9),
+			'https_enabled' => true,
+			'url_regex' => [
+				'#conferences/.*?([\d\w_-]+)(?:/oembed)?.html$#is'
+			],
+			'id_regex'    => [
+				'#^([\d\w_-]+)$#is'
+			]
 		]
 	];
 


### PR DESCRIPTION
http://media.ccc.de is the video platform of the Chaos Computer Club, which also publishes videos for some other conferences.