### PR TITLE
extra quote generates an invalid html

### DIFF
--- a/EmbedVideo.hooks.php
+++ b/EmbedVideo.hooks.php
@@ -306,7 +306,7 @@ class EmbedVideoHooks {
 
 		if (self::getAlignment() !== false) {
 			$classString .= " ev_" . self::getAlignment();
-			$styleString .= " width: " . ( self::$service->getWidth() + 6 ) . "px;'";
+			$styleString .= " width: " . ( self::$service->getWidth() + 6 ) . "px;";
 		}
 
 		if ($addClass) {


### PR DESCRIPTION
Generated code:
  -  div class='embedvideo ev_center autoResize' style=' width: 646px;''

expected result:
   - div class='embedvideo ev_center autoResize' style=' width: 646px;'