### PR TITLE
Add @noflip rules for CSS position classes, for proper RTL alignment

### DIFF
--- a/css/embedvideo.css
+++ b/css/embedvideo.css
@@ -8,11 +8,13 @@ div.embedvideo.ev_center > .embedvideowrap {
 	margin-right: auto;
 }
 
+/* @noflip */
 div.embedvideo.ev_left {
 	clear: left;
 	float: left;
 }
 
+/* @noflip */
 div.embedvideo.ev_right {
 	clear: right;
 	float: right;


### PR DESCRIPTION
Otherwise, when you specify you want the video on the left in an RTL language, you actually get it on the right, and vice versa.