### PR TITLE
Add "position": "top" to ext.embedVideo.styles

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -59,6 +59,7 @@
 			"styles": [
 				"css/embedvideo.css"
 			],
+			"position": "top",
 			"targets": [
 				"desktop",
 				"mobile"


### PR DESCRIPTION
This fixes error that appears in log "Got error 'PHP message: PHP Warning:  OutputPage::getModuleStyles: style module should define its position explicitly: ext.embedVideo.styles ResourceLoaderFileModule..."