### PR TITLE
Youtube use nocookie version by default.

### DIFF
--- a/classes/VideoService.php
+++ b/classes/VideoService.php
@@ -380,6 +380,7 @@ class VideoService {
 			'https_enabled'	=> true,
 			'url_regex'		=> [
 				'#v=([\d\w-]+)(?:&\S+?)?#is',
+				'#youtube(?:-nocookie)?\.com/embed/([\d\w-]+)#is',
 				'#youtu\.be/([\d\w-]+)#is'
 			],
 			'id_regex'		=> [

--- a/classes/VideoService.php
+++ b/classes/VideoService.php
@@ -374,7 +374,7 @@ class VideoService {
 			]
 		],
 		'youtube' => [
-			'embed'			=> '<iframe src="//www.youtube.com/embed/%1$s?%4$s" width="%2$d" height="%3$d" frameborder="0" allowfullscreen="true"></iframe>',
+			'embed'			=> '<iframe src="//www.youtube-nocookie.com/embed/%1$s?%4$s" width="%2$d" height="%3$d" frameborder="0" allowfullscreen="true"></iframe>',
 			'default_width'	=> 640,
 			'default_ratio'	=> 1.77777777777778, // (16 / 9)
 			'https_enabled'	=> true,


### PR DESCRIPTION
With GDPR coming up we wanted to avoid any needless cookies. This is a nice simple service youtube provide to avoid google's cookies.

I haven't tested with oembed or playlists and so haven't included those changes in the patch.