### PR TITLE
Return "manifest_version" to extension.json (was accidentally deleted)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -80,5 +80,6 @@
 		"ParserFirstCallInit": [
 			"EmbedVideoHooks::onParserFirstCallInit"
 		]
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
Same as pull request #84.

This reverts accidental deletion of "manifest_version" from extension.json in commit f121d714b3f3fdf61ff606e95700285dee868fc3 .